### PR TITLE
fix notifications expire-time

### DIFF
--- a/usr/local/sbin/updatesnotify
+++ b/usr/local/sbin/updatesnotify
@@ -8,10 +8,10 @@ if sed -n '/\b0 package\b/p' $tmpfile | grep -q 'package'; then
 	if [ -f "/usr/local/sbin/.updnotify" ]; then
 		:
 	else 
-		notify-send -i /usr/share/icons/Faenza/places/48/distributor-logo-ubuntu.png --expire-time=5000 'Lite Updates Notify' "Your system is up to date" & touch "/usr/local/sbin/.updnotify"
+		notify-send -i /usr/share/icons/Faenza/places/48/distributor-logo-ubuntu.png 'Lite Updates Notify' "Your system is up to date" & touch "/usr/local/sbin/.updnotify"
 	fi
 else
-    notify-send -i /usr/share/icons/Faenza/apps/48/system-software-installer.png --expire-time=10000 'Install Updates' "$UPD"
+    notify-send -i /usr/share/icons/Faenza/apps/48/system-software-installer.png 'Install Updates' "$UPD"
     rm -f "/usr/local/sbin/.updnotify" >/dev/null
 fi
 xhost - >/dev/null 2>&1


### PR DESCRIPTION
remove --expire-time so that users notifications ‘disappear after’
preferences are used. See Menu, All Settings, Notifications